### PR TITLE
Fixed a SyntaxError

### DIFF
--- a/360Scraper.py
+++ b/360Scraper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: cp936 -*-
 import requests
 from bs4 import BeautifulSoup
 from random import choice


### PR DESCRIPTION
Fixed "SyntaxError: Non-ASCII character '\xe6' in file 360Scraper.py on line 8, but no encoding declared" caused by Chinese characters on line 8 by declaring source code encoding at the beginning of the program